### PR TITLE
Fixes violation of Comparable contract

### DIFF
--- a/main/sibgenerator
+++ b/main/sibgenerator
@@ -3,7 +3,11 @@
 basedir=${0%/*}
 . ${basedir}/classpath.sh
 
-cmd="java -Xmx16000M -XX:-UseGCOverheadLimit sib.generator.ScalableGenerator $@"
+# create outputDir if not exists
+[ ! -d outputDir ] && mkdir outputDir
+
+# use legacy sorting for backward compability with pre java 8 comparators
+cmd="java -Djava.util.Arrays.useLegacyMergeSort=true -Xmx16000M -XX:-UseGCOverheadLimit sib.generator.ScalableGenerator $@"
 
 #cmd="java -Xmx512M -XX:-UseGCOverheadLimit sib.generator.ScalableGenerator $@"
 


### PR DESCRIPTION
Fixes violation of Comparable contract which is explicitly enforced from java 8

Fixes exception: "Comparison method violates its general contract!" when running sibgenerator with java version 8+. (Tested on 12)
From java 8 the Comparators are checked more carefully if they do not break any contract.

The use of `-Djava.util.Arrays.useLegacyMergeSort=true` allows to loosen this enforcement and is a quick fix.
A better fix would be to update the Comparator in src/sib/util/ExternalSort.java